### PR TITLE
Untested: homescreen bar transparency

### DIFF
--- a/core/res/res/values/bools.xml
+++ b/core/res/res/values/bools.xml
@@ -15,6 +15,8 @@
 -->
 
 <resources>
+    <bool name="config_enableTranslucentDecor">true</bool>
+    <bool name="config_enableLockScreenTranslucentDecor">true</bool>
     <bool name="kg_enable_camera_default_widget">true</bool>
     <bool name="kg_center_small_widgets_vertically">false</bool>
     <bool name="kg_top_align_page_shrink_on_bouncer_visible">true</bool>


### PR DESCRIPTION
This should make launcher and lockscreen bars (navbar & statusbar) transparent.
I don't see a reason why this should be N5 only.
